### PR TITLE
Add Segment user traits as Batch user attributes

### DIFF
--- a/Pod/Classes/SEGBatchIntegration.m
+++ b/Pod/Classes/SEGBatchIntegration.m
@@ -175,6 +175,9 @@ NSString *const SEGBatchIntegrationSettingsAdvancedDeviceInformation = @"canUseA
 {
     BatchUserDataEditor *editor = [BatchUser editor];
     [editor setIdentifier:payload.userId];
+    [payload.traits enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+        [editor setAttribute:obj forKey:key];
+    }];
     [editor save];
     SEGLog(@"[BatchUser %@];", editor);
 }

--- a/Pod/Classes/SEGBatchIntegration.m
+++ b/Pod/Classes/SEGBatchIntegration.m
@@ -7,6 +7,9 @@
     NSRegularExpression *eventNameSnakeCaseRegexp;
     NSRegularExpression *eventNameSlugifyRegexp;
     NSRegularExpression *eventNameDoubleUnderscoreRegexp;
+    NSRegularExpression *eventKeySnakeCaseRegexp;
+    NSRegularExpression *eventKeySlugifyRegexp;
+    NSRegularExpression *eventKeyDoubleUnderscoreRegexp;
 }
 
 BOOL SEGBatchIntegrationEnableAutomaticStart = true;
@@ -93,6 +96,9 @@ NSString *const SEGBatchIntegrationSettingsAdvancedDeviceInformation = @"canUseA
         eventNameSnakeCaseRegexp = [NSRegularExpression regularExpressionWithPattern:@"(?<!^|[A-Z])[A-Z]" options:0 error:nil];
         eventNameSlugifyRegexp = [NSRegularExpression regularExpressionWithPattern:@"[^a-zA-Z0-9]" options:0 error:nil];
         eventNameDoubleUnderscoreRegexp = [NSRegularExpression regularExpressionWithPattern:@"_+" options:0 error:nil];
+        eventKeySnakeCaseRegexp = [NSRegularExpression regularExpressionWithPattern:@"(?<!^|[A-Z])[A-Z]" options:0 error:nil];
+        eventKeySlugifyRegexp = [NSRegularExpression regularExpressionWithPattern:@"[^a-zA-Z0-9]" options:0 error:nil];
+        eventKeyDoubleUnderscoreRegexp = [NSRegularExpression regularExpressionWithPattern:@"_+" options:0 error:nil];
     }
     return self;
 }
@@ -103,6 +109,36 @@ NSString *const SEGBatchIntegrationSettingsAdvancedDeviceInformation = @"canUseA
         return nil;
     }
     
+    NSMutableString *mutableName = [name mutableCopy];
+
+    [eventNameSnakeCaseRegexp replaceMatchesInString:mutableName
+                                             options:0
+                                               range:NSMakeRange(0, [mutableName length])
+                                        withTemplate:@"_$0"];
+
+    [eventNameSlugifyRegexp replaceMatchesInString:mutableName
+                                           options:0
+                                             range:NSMakeRange(0, [mutableName length])
+                                      withTemplate:@"_"];
+
+    [eventNameDoubleUnderscoreRegexp replaceMatchesInString:mutableName
+                                                    options:0
+                                                      range:NSMakeRange(0, [mutableName length])
+                                               withTemplate:@"_"];
+
+    // We don't need to take Unicode into account as we're down to single char characters
+    NSRange range = {0, MIN([mutableName length], 30)};
+    name = [mutableName substringWithRange:range];
+
+    return [name uppercaseString];
+}
+
+- (NSString*)formatKeyName:(NSString*)name
+{
+    if (!name) {
+        return nil;
+    }
+
     NSMutableString *mutableName = [name mutableCopy];
     
     [eventNameSnakeCaseRegexp replaceMatchesInString:mutableName
@@ -176,7 +212,8 @@ NSString *const SEGBatchIntegrationSettingsAdvancedDeviceInformation = @"canUseA
     BatchUserDataEditor *editor = [BatchUser editor];
     [editor setIdentifier:payload.userId];
     [payload.traits enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
-        [editor setAttribute:obj forKey:key];
+        NSString *formattedKey = [self formatKeyName:key];
+        [editor setAttribute:obj forKey:formattedKey];
     }];
     [editor save];
     SEGLog(@"[BatchUser %@];", editor);


### PR DESCRIPTION
I think it would be really helpful to have the user traits uploaded from Segment to Batch as attributes. I know that feature was dropped because Batch has strict limitations regarding the formatting of user attributes.

I have been reading the documentation at https://github.com/BatchLabs/ios-sdk/blob/7732a99453aa3956cb9170e7f1e76f549811bf7e/SDK/Batch.embeddedframework/Batch.framework/Headers/BatchUser.h#L140-L165, but Batch's SDK exact behavior is unclear to me. Will the attributes just get dropped or will the SDK throw an exception?

In the meantime, I am just introducing the following code as a way to start the discussion and check if there is any interest in supporting that feature. Please let me know what you think.