### PR TITLE
Upgrade Analytics to 4.0

### DIFF
--- a/Segment-Batch.podspec
+++ b/Segment-Batch.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.static_framework = true
   
-  s.dependency 'Analytics', '~> 3.0'
+  s.dependency 'Analytics', '~> 4.0'
   s.default_subspec = 'Standard'
 
   s.subspec 'Standard' do |std|


### PR DESCRIPTION
Segment has released version 4.0 of their `Analytics` pod. `Segment-Batch` locking `Analytics` at 3.0 causes some issues with other Segment integration we are using.