### PR TITLE
Support Analytics 4.1 pod

### DIFF
--- a/Pod/Classes/SEGBatchIntegration.h
+++ b/Pod/Classes/SEGBatchIntegration.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 
+#if defined(__has_include) && __has_include(<Analytics/SEGIntegration.h>)
 #import <Analytics/SEGIntegration.h>
+#else
+#import <Segment/SEGIntegration.h>
+#endif
 
 @interface SEGBatchIntegration : NSObject <SEGIntegration>
 

--- a/Pod/Classes/SEGBatchIntegration.m
+++ b/Pod/Classes/SEGBatchIntegration.m
@@ -1,5 +1,11 @@
 #import "SEGBatchIntegration.h"
+
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalyticsUtils.h>)
 #import <Analytics/SEGAnalyticsUtils.h>
+#else
+#import <Segment/SEGAnalyticsUtils.h>
+#endif
+
 #import <Batch/Batch.h>
 
 @implementation SEGBatchIntegration

--- a/Pod/Classes/SEGBatchIntegrationFactory.h
+++ b/Pod/Classes/SEGBatchIntegrationFactory.h
@@ -1,5 +1,10 @@
 #import <Foundation/Foundation.h>
+
+#if defined(__has_include) && __has_include(<Analytics/SEGIntegrationFactory.h>)
 #import <Analytics/SEGIntegrationFactory.h>
+#else
+#import <Segment/SEGIntegrationFactory.h>
+#endif
 
 @interface SEGBatchIntegrationFactory : NSObject <SEGIntegrationFactory>
 


### PR DESCRIPTION
In the version 4.1.0 of Segment, they “Renamed module from Analytics to Segment” (see [changelog](https://github.com/segmentio/analytics-ios/releases/tag/4.1.0))
It brakes several imports, and developers might see errors like :
> 'Analytics/SEGIntegrationFactory.h' file not found

This fix allow to work with all versions since Analytics 4.0.0
